### PR TITLE
Fh 41/search query parameters

### DIFF
--- a/frontend/app/freelances/search/page.tsx
+++ b/frontend/app/freelances/search/page.tsx
@@ -291,6 +291,7 @@ function Page() {
                     key={skill.id}
                     value={skill.name}
                     onClick={() => handleSkillToggle(skill)}
+                    isActive={selectedSkills.some((s) => s.id === skill.id)}
                   />
                 ))}
             </div>

--- a/frontend/app/freelances/search/page.tsx
+++ b/frontend/app/freelances/search/page.tsx
@@ -28,6 +28,7 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "@/components/ui/pagination";
+import { useSearchParams } from "next/navigation";
 
 const MINIMUM_AVERAGE_DAILY_RATE = 0;
 const MAXIMUM_AVERAGE_DAILY_RATE = 1500;
@@ -51,6 +52,8 @@ const SENIORITY_OPTIONS: SeniorityOption[] = [
 ];
 
 function Page() {
+  const searchParams = useSearchParams();
+
   const [minimumAverageDailyRate, setMinimumAverageDailyRate] = useState(
     MINIMUM_AVERAGE_DAILY_RATE,
   );
@@ -76,12 +79,25 @@ function Page() {
   // Fetch skills
   useEffect(() => {
     const fetchSkills = async () => {
-      const skills = await getSkills();
-      setSkills(skills.slice(0, 10)); // Limit to 10 skills for display
+      let localSkills = await getSkills();
+      localSkills = localSkills.slice(0, 10); // Limit to 10 skills for display
+
+      // Get skill parameters from URL
+      const skillParameters = searchParams.getAll("skills");
+
+      if (localSkills.length > 0 && skillParameters.length > 0) {
+        const selectedSkills = localSkills.filter((skill) =>
+          skillParameters.includes(skill.name),
+        );
+        setSelectedSkills(selectedSkills);
+      }
+
+      setSkills(localSkills);
       setSkillsLoading(false);
     };
 
     fetchSkills();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const fetchFreelances = useCallback(
@@ -102,6 +118,18 @@ function Page() {
         page,
         pageSize: DEFAULT_PAGE_SIZE,
       });
+
+      // Update URL search params
+      const params = new URLSearchParams();
+      params.set("query", query);
+      params.set("page", page.toString());
+      selectedSkills.forEach((skill) => {
+        params.append("skills", skill.name);
+      });
+      if (selectedSeniority) {
+        params.set("seniority", selectedSeniority);
+      }
+      window.history.replaceState({}, "", `?${params.toString()}`);
 
       setFreelanceResults(results);
       setFreelancesLoading(false);
@@ -129,6 +157,28 @@ function Page() {
     // Cancel any pending debounced calls when component unmounts
     return () => debouncedFetchFreelances.clear();
   }, [debouncedFetchFreelances, searchQuery, currentPage]);
+
+  // Upon page load if there are any search parameters
+  useEffect(() => {
+    const query = searchParams.get("query");
+    const page = searchParams.get("page");
+    const seniority = searchParams.get("seniority");
+
+    if (query) {
+      setSearchQuery(query);
+    }
+
+    if (page) {
+      const pageNumber = parseInt(page, 10);
+      if (!isNaN(pageNumber)) {
+        setCurrentPage(pageNumber);
+      }
+    }
+
+    if (seniority) {
+      setSelectedSeniority(seniority);
+    }
+  }, [searchParams]);
 
   // Handle search form submission
   const handleSearch = async (formData: FormData) => {

--- a/frontend/components/common/toggle-badge/index.tsx
+++ b/frontend/components/common/toggle-badge/index.tsx
@@ -6,15 +6,17 @@ import { useState } from "react";
 function ToggleBadge({
   value,
   onClick,
+  isActive = false,
 }: {
   value: string;
   onClick?: (value: string, newState: boolean) => void;
+  isActive?: boolean;
 }) {
-  const [isActive, setIsActive] = useState(false);
+  const [localIsActive, setLocalIsActive] = useState(isActive);
 
   const handleClick = () => {
-    const newState = !isActive;
-    setIsActive(newState);
+    const newState = !localIsActive;
+    setLocalIsActive(newState);
     if (onClick) {
       onClick(value, newState);
     }

--- a/frontend/components/common/toggle-badge/index.tsx
+++ b/frontend/components/common/toggle-badge/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Badge } from "@/components/ui/badge";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 function ToggleBadge({
   value,
@@ -13,6 +13,10 @@ function ToggleBadge({
   isActive?: boolean;
 }) {
   const [localIsActive, setLocalIsActive] = useState(isActive);
+
+  useEffect(() => {
+    setLocalIsActive(isActive);
+  }, [isActive]);
 
   const handleClick = () => {
     const newState = !localIsActive;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1866,7 +1866,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.0.tgz",
       "integrity": "sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1876,7 +1876,7 @@
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-jFf/woGTVTjUJsl2O7hcopJ1r0upqoq/vIOoCj0yLh3RIXxWcljlpuZ+vEBRXsymD1jhfeJrlyTy/S1UW+4y1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -2892,7 +2892,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {


### PR DESCRIPTION
This pull request introduces enhancements to the freelance search page, including support for URL-based search parameters, improvements to the `ToggleBadge` component, and minor package configuration updates. The most significant changes are grouped into functional updates and dependency updates.

### Functional Updates:

* **URL-based Search Parameters**:
  - Integrated `useSearchParams` from `next/navigation` to manage URL parameters. This enables persisting search filters (query, page, skills, seniority) in the URL and preloading them when the page loads. (`frontend/app/freelances/search/page.tsx`: [[1]](diffhunk://#diff-16e8e647052733ece9a7a698993149562bf9fe3c1b3ceca390b12f2bdf07821bR31) [[2]](diffhunk://#diff-16e8e647052733ece9a7a698993149562bf9fe3c1b3ceca390b12f2bdf07821bR55-R56) [[3]](diffhunk://#diff-16e8e647052733ece9a7a698993149562bf9fe3c1b3ceca390b12f2bdf07821bL79-R100) [[4]](diffhunk://#diff-16e8e647052733ece9a7a698993149562bf9fe3c1b3ceca390b12f2bdf07821bR122-R133) [[5]](diffhunk://#diff-16e8e647052733ece9a7a698993149562bf9fe3c1b3ceca390b12f2bdf07821bR161-R182)
  - Updated the skill filter to highlight active selections based on URL parameters. (`frontend/app/freelances/search/page.tsx`: [frontend/app/freelances/search/page.tsxR294](diffhunk://#diff-16e8e647052733ece9a7a698993149562bf9fe3c1b3ceca390b12f2bdf07821bR294))

* **`ToggleBadge` Component Update**:
  - Modified the `ToggleBadge` component to accept an external `isActive` prop, allowing its state to be controlled externally. This ensures better integration with the new search filter logic. (`frontend/components/common/toggle-badge/index.tsx`: [frontend/components/common/toggle-badge/index.tsxR9-R19](diffhunk://#diff-050e8c6097bc0e61daeab7b9fd03c0f12b4faeb6562da556495b33708f9c7abdR9-R19))

### Dependency Updates:

* Updated `package-lock.json` to mark several dependencies (`@types/react`, `@types/react-dom`, `csstype`) as `devOptional` instead of `dev`. This is a minor configuration change with no functional impact. (`frontend/package-lock.json`: [[1]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL1869-R1869) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL1879-R1879) [[3]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL2895-R2895)