### PR TITLE
maj api job-posting + project

### DIFF
--- a/backend/src/auth/job-posting-access.guard.ts
+++ b/backend/src/auth/job-posting-access.guard.ts
@@ -1,0 +1,60 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from '../common/prisma/prisma.service';
+import { User } from '@prisma/client';
+
+@Injectable()
+export class JobPostingAccessGuard implements CanActivate {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<
+      Request & { user: User; params: { id: string } }
+    >();
+    
+    const user = request.user;
+    const jobPostingId = request.params.id;
+
+    if (!user || !jobPostingId) {
+      throw new ForbiddenException('Accès non autorisé');
+    }
+
+    const jobPosting = await this.prismaService.jobPosting.findUnique({
+      where: { id: jobPostingId },
+      include: {
+        company: {
+          include: {
+            user: true,
+          },
+        },
+      },
+    });
+
+    if (!jobPosting) {
+      throw new NotFoundException(`Annonce avec l'ID ${jobPostingId} introuvable`);
+    }
+
+    const hasAccess = this.checkUserAccess(user, jobPosting);
+
+    if (!hasAccess) {
+      throw new ForbiddenException(
+        'Vous n\'avez pas l\'autorisation d\'accéder à cette annonce. Seule l\'entreprise propriétaire peut y accéder.',
+      );
+    }
+
+    return true;
+  }
+
+  private checkUserAccess(user: User, jobPosting: any): boolean {
+    if (jobPosting.company && jobPosting.company.user.id === user.id) {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/backend/src/auth/project-access.guard.ts
+++ b/backend/src/auth/project-access.guard.ts
@@ -1,0 +1,71 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from '../common/prisma/prisma.service';
+import { User } from '@prisma/client';
+
+@Injectable()
+export class ProjectAccessGuard implements CanActivate {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<
+      Request & { user: User; params: { id: string } }
+    >();
+    
+    const user = request.user;
+    const projectId = request.params.id;
+
+    if (!user || !projectId) {
+      throw new ForbiddenException('Accès non autorisé');
+    }
+
+    // Récupérer le projet avec les informations nécessaires
+    const project = await this.prismaService.project.findUnique({
+      where: { id: projectId },
+      include: {
+        freelance: {
+          include: {
+            user: true,
+          },
+        },
+        company: {
+          include: {
+            user: true,
+          },
+        },
+      },
+    });
+
+    if (!project) {
+      throw new NotFoundException(`Projet avec l'ID ${projectId} introuvable`);
+    }
+
+    // Vérifier si l'utilisateur a accès au projet
+    const hasAccess = this.checkUserAccess(user, project);
+
+    if (!hasAccess) {
+      throw new ForbiddenException(
+        'Vous n\'avez pas l\'autorisation d\'accéder à ce projet. Seuls les membres assignés au projet peuvent y accéder.',
+      );
+    }
+
+    return true;
+  }
+
+  private checkUserAccess(user: User, project: any): boolean {
+    if (project.freelance && project.freelance.user.id === user.id) {
+      return true;
+    }
+
+    if (project.company && project.company.user.id === user.id) {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/backend/src/job-postings/job-postings.controller.spec.ts
+++ b/backend/src/job-postings/job-postings.controller.spec.ts
@@ -115,7 +115,8 @@ describe('JobPostingsController', () => {
   describe('findAll', () => {
     it('should return an array of job postings', async () => {
       jest.spyOn(jobPostingsService, 'findAll').mockResolvedValue([jobPosting]);
-      expect(await jobPostingsController.findAll()).toEqual([jobPosting]);
+      expect(await jobPostingsController.findAll(mockCompanyUser)).toEqual([jobPosting]);
+      expect(jobPostingsService.findAll).toHaveBeenCalledWith(mockCompanyUser.id);
     });
   });
 
@@ -141,7 +142,7 @@ describe('JobPostingsController', () => {
         await jobPostingsController.update(jobPosting.id, {
           ...updatedJobPosting,
           totalAmount: updatedJobPosting.totalAmount || undefined,
-        }),
+        }, mockCompanyUser),
       ).toEqual(updatedJobPosting);
     });
   });
@@ -149,7 +150,7 @@ describe('JobPostingsController', () => {
   describe('remove', () => {
     it('should remove a job posting', async () => {
       jest.spyOn(jobPostingsService, 'remove').mockResolvedValue(jobPosting);
-      expect(await jobPostingsController.remove(jobPosting.id)).toEqual(
+      expect(await jobPostingsController.remove(jobPosting.id, mockCompanyUser)).toEqual(
         jobPosting,
       );
     });

--- a/backend/src/job-postings/job-postings.controller.spec.ts
+++ b/backend/src/job-postings/job-postings.controller.spec.ts
@@ -114,9 +114,9 @@ describe('JobPostingsController', () => {
 
   describe('findAll', () => {
     it('should return an array of job postings', async () => {
-      jest.spyOn(jobPostingsService, 'findAll').mockResolvedValue([jobPosting]);
+      jest.spyOn(jobPostingsService, 'findAllByRole').mockResolvedValue([jobPosting]);
       expect(await jobPostingsController.findAll(mockCompanyUser)).toEqual([jobPosting]);
-      expect(jobPostingsService.findAll).toHaveBeenCalledWith(mockCompanyUser.id);
+      expect(jobPostingsService.findAllByRole).toHaveBeenCalledWith(mockCompanyUser);
     });
   });
 

--- a/backend/src/job-postings/job-postings.controller.ts
+++ b/backend/src/job-postings/job-postings.controller.ts
@@ -9,6 +9,7 @@ import {
   ParseUUIDPipe,
   HttpCode,
   UseInterceptors,
+  UseGuards,
 } from '@nestjs/common';
 import { JobPostingsService } from './job-postings.service';
 import { CreateJobPostingDto } from './dto/create-job-posting.dto';
@@ -23,6 +24,8 @@ import { User } from '@prisma/client';
 import { CurrentUser } from '../common/decorators/currentUsers.decorators';
 import { OptionalAuthInterceptor } from '../common/interceptors/optional-auth.interceptor';
 import { StripeService } from '../common/stripe/stripe.service';
+import { AuthentikAuthGuard } from '../auth/auth.guard';
+import { JobPostingAccessGuard } from '../auth/job-posting-access.guard';
 
 @ApiTags('job-postings')
 @Controller('job-postings')
@@ -49,23 +52,80 @@ export class JobPostingsController {
   }
 
   @Get()
+  @UseGuards(AuthentikAuthGuard)
   @ApiOperation({
     summary: 'Find all job postings',
-    description: 'Retrieve all job postings with their skills and company',
+    description: 'Retrieve all job postings for the authenticated company',
   })
   @ApiResponse({
     status: 200,
-    description: 'Returns all job postings',
+    description: 'Returns all job postings for the authenticated company',
     type: [JobPostingResponseDto],
   })
-  findAll(): Promise<JobPostingResponseDto[]> {
-    return this.jobPostingsService.findAll();
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+  })
+  findAll(@CurrentUser() user: User): Promise<JobPostingResponseDto[]> {
+    return this.jobPostingsService.findAll(user.id);
+  }
+
+  @Get('public')
+  @ApiOperation({
+    summary: 'Find all published job postings',
+    description: 'Retrieve all published job postings (public access for freelances)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns all published job postings',
+    type: [JobPostingResponseDto],
+  })
+  findAllPublic(): Promise<JobPostingResponseDto[]> {
+    return this.jobPostingsService.findAll(); // Sans userId = mode public
+  }
+
+  @Get('company/:id')
+  @UseGuards(AuthentikAuthGuard, JobPostingAccessGuard)
+  @ApiOperation({
+    summary: 'Find a job posting by ID (company access)',
+    description: 'Retrieve a job posting by its ID - accessible only by the company owner',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'The ID of the job posting (must be a valid UUID)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns the job posting with the specified ID',
+    type: JobPostingResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid UUID format',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden - You do not have access to this job posting',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Job posting not found',
+  })
+  findOneCompany(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: User,
+  ): Promise<JobPostingResponseDto | null> {
+    return this.jobPostingsService.findOne(id);
   }
 
   @Get(':id')
   @ApiOperation({
-    summary: 'Find a job posting by ID',
-    description: 'Retrieve a job posting by its ID with skills and company',
+    summary: 'Find a job posting by ID (public access)',
+    description: 'Retrieve a job posting by its ID - public access for freelances',
   })
   @ApiParam({
     name: 'id',
@@ -91,9 +151,10 @@ export class JobPostingsController {
   }
 
   @Patch(':id')
+  @UseGuards(AuthentikAuthGuard, JobPostingAccessGuard)
   @ApiOperation({
     summary: 'Update a job posting',
-    description: 'Update a job posting with optional skills modification',
+    description: 'Update a job posting with optional skills modification (company owner only)',
   })
   @ApiParam({
     name: 'id',
@@ -109,20 +170,30 @@ export class JobPostingsController {
     description: 'Invalid UUID format',
   })
   @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden - You do not have access to this job posting',
+  })
+  @ApiResponse({
     status: 404,
     description: 'Job posting not found',
   })
   update(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateJobPostingDto: UpdateJobPostingDto,
+    @CurrentUser() user: User,
   ): Promise<JobPostingResponseDto> {
     return this.jobPostingsService.update(id, updateJobPostingDto);
   }
 
   @Delete(':id')
+  @UseGuards(AuthentikAuthGuard, JobPostingAccessGuard)
   @ApiOperation({
     summary: 'Remove a job posting',
-    description: 'Delete a job posting by its ID',
+    description: 'Delete a job posting by its ID (company owner only)',
   })
   @ApiParam({
     name: 'id',
@@ -138,11 +209,20 @@ export class JobPostingsController {
     description: 'Invalid UUID format',
   })
   @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden - You do not have access to this job posting',
+  })
+  @ApiResponse({
     status: 404,
     description: 'Job posting not found',
   })
   remove(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: User,
   ): Promise<JobPostingResponseDto> {
     return this.jobPostingsService.remove(id);
   }

--- a/backend/src/job-postings/job-postings.controller.ts
+++ b/backend/src/job-postings/job-postings.controller.ts
@@ -55,11 +55,11 @@ export class JobPostingsController {
   @UseGuards(AuthentikAuthGuard)
   @ApiOperation({
     summary: 'Find all job postings',
-    description: 'Retrieve all job postings for the authenticated company',
+    description: 'Retrieve job postings based on user role: companies see their own, freelances see all published',
   })
   @ApiResponse({
     status: 200,
-    description: 'Returns all job postings for the authenticated company',
+    description: 'Returns job postings based on user role',
     type: [JobPostingResponseDto],
   })
   @ApiResponse({
@@ -67,21 +67,7 @@ export class JobPostingsController {
     description: 'Unauthorized',
   })
   findAll(@CurrentUser() user: User): Promise<JobPostingResponseDto[]> {
-    return this.jobPostingsService.findAll(user.id);
-  }
-
-  @Get('public')
-  @ApiOperation({
-    summary: 'Find all published job postings',
-    description: 'Retrieve all published job postings (public access for freelances)',
-  })
-  @ApiResponse({
-    status: 200,
-    description: 'Returns all published job postings',
-    type: [JobPostingResponseDto],
-  })
-  findAllPublic(): Promise<JobPostingResponseDto[]> {
-    return this.jobPostingsService.findAll(); // Sans userId = mode public
+    return this.jobPostingsService.findAllByRole(user);
   }
 
   @Get('company/:id')

--- a/backend/src/job-postings/job-postings.service.ts
+++ b/backend/src/job-postings/job-postings.service.ts
@@ -52,7 +52,30 @@ export class JobPostingsService {
     });
   }
 
-  async findAll(): Promise<JobPosting[]> {
+  async findAll(userId?: string): Promise<JobPosting[]> {
+    if (userId) {
+      return this.prisma.jobPosting.findMany({
+        where: {
+          company: {
+            userId: userId,
+          },
+        },
+        include: {
+          skills: true,
+          company: {
+            include: {
+              user: true,
+            },
+          },
+          checkpoints: true,
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+      });
+    }
+
+    // Sinon, retourner les annonces publiques (pour les freelances)
     return this.prisma.jobPosting.findMany({
       where: {
         status: 'PUBLISHED', // Ne retourner que les annonces publiées

--- a/backend/src/job-postings/job-postings.service.ts
+++ b/backend/src/job-postings/job-postings.service.ts
@@ -52,6 +52,55 @@ export class JobPostingsService {
     });
   }
 
+  async findAllByRole(user: User): Promise<JobPosting[]> {
+    if (user.role === 'COMPANY') {
+      return this.prisma.jobPosting.findMany({
+        where: {
+          company: {
+            userId: user.id,
+          },
+        },
+        include: {
+          skills: true,
+          company: {
+            include: {
+              user: true,
+            },
+          },
+          checkpoints: true,
+          candidates: true,
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+      });
+    } else {
+      return this.prisma.jobPosting.findMany({
+        where: {
+          status: 'PUBLISHED',
+          candidates: {
+            none: {
+              status: 'ACCEPTED', 
+            },
+          },
+        },
+        include: {
+          skills: true,
+          company: {
+            include: {
+              user: true,
+            },
+          },
+          checkpoints: true,
+          candidates: true,
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+      });
+    }
+  }
+
   async findAll(userId?: string): Promise<JobPosting[]> {
     if (userId) {
       return this.prisma.jobPosting.findMany({

--- a/backend/src/projects/projects.controller.spec.ts
+++ b/backend/src/projects/projects.controller.spec.ts
@@ -154,7 +154,7 @@ describe('ProjectController', () => {
       jest
         .spyOn(projectsService, 'create')
         .mockResolvedValue(simpleProjectMock as any);
-      expect(await projectController.create(createProjectDto)).toEqual(
+      expect(await projectController.create(createProjectDto, mockUser)).toEqual(
         simpleProjectMock,
       );
     });
@@ -165,7 +165,8 @@ describe('ProjectController', () => {
       jest
         .spyOn(projectsService, 'findAll')
         .mockResolvedValue([simpleProjectMock as any]);
-      expect(await projectController.findAll()).toEqual([simpleProjectMock]);
+      expect(await projectController.findAll(mockUser)).toEqual([simpleProjectMock]);
+      expect(projectsService.findAll).toHaveBeenCalledWith(mockUser.id);
     });
   });
 
@@ -174,7 +175,7 @@ describe('ProjectController', () => {
       jest
         .spyOn(projectsService, 'findOne')
         .mockResolvedValue(simpleProjectMock as any);
-      expect(await projectController.findOne(simpleProjectMock.id)).toEqual(
+      expect(await projectController.findOne(simpleProjectMock.id, mockUser)).toEqual(
         simpleProjectMock,
       );
     });
@@ -188,7 +189,7 @@ describe('ProjectController', () => {
       expect(
         await projectController.update(simpleProjectMock.id, {
           name: 'Updated Project Title',
-        }),
+        }, mockUser),
       ).toEqual(updatedProjectWithRelations);
     });
   });
@@ -198,7 +199,7 @@ describe('ProjectController', () => {
       jest
         .spyOn(projectsService, 'remove')
         .mockResolvedValue(simpleProjectMock as any);
-      expect(await projectController.remove(simpleProjectMock.id)).toEqual(
+      expect(await projectController.remove(simpleProjectMock.id, mockUser)).toEqual(
         simpleProjectMock,
       );
     });

--- a/backend/src/projects/projects.controller.ts
+++ b/backend/src/projects/projects.controller.ts
@@ -147,7 +147,7 @@ export class ProjectController {
     @Body() updateProjectDto: UpdateProjectDto,
     @CurrentUser() user: User,
   ): Promise<ProjectResponseDto> {
-    return this.projectsService.update(id, updateProjectDto);
+    return this.projectsService.update(id, updateProjectDto, user.id);
   }
 
   @Delete(':id')

--- a/backend/src/projects/projects.controller.ts
+++ b/backend/src/projects/projects.controller.ts
@@ -185,7 +185,7 @@ export class ProjectController {
     @Param('id') id: string,
     @CurrentUser() user: User,
   ): Promise<ProjectResponseDto> {
-    return this.projectsService.remove(id);
+    return this.projectsService.remove(id, user.id);
   }
 
   @Get('company/:companyId')

--- a/backend/src/projects/projects.controller.ts
+++ b/backend/src/projects/projects.controller.ts
@@ -108,7 +108,7 @@ export class ProjectController {
     @Param('id') id: string,
     @CurrentUser() user: User,
   ): Promise<ProjectResponseDto> {
-    return this.projectsService.findOne(id);
+    return this.projectsService.findOne(id, user.id);
   }
 
   @Patch(':id')

--- a/backend/src/projects/projects.service.ts
+++ b/backend/src/projects/projects.service.ts
@@ -118,12 +118,45 @@ export class ProjectsService {
     });
   }
 
-  // Find all projects
-  async findAll() {
+  // Find all projects accessible to the user
+  async findAll(userId: string) {
     const projects = await this.prismaService.project.findMany({
+      where: {
+        OR: [
+          {
+            freelance: {
+              userId: userId,
+            },
+          },
+          {
+            company: {
+              userId: userId,
+            },
+          },
+        ],
+      },
       include: {
-        freelance: true,
-        jobPosting: true,
+        freelance: {
+          include: {
+            user: true,
+            skills: true,
+          },
+        },
+        jobPosting: {
+          include: {
+            company: true,
+            skills: true,
+          },
+        },
+        company: {
+          include: {
+            user: true,
+          },
+        },
+        conversation: true,
+      },
+      orderBy: {
+        createdAt: 'desc',
       },
     });
 


### PR DESCRIPTION
Désormais ces deux API ne renvoient que les données strictement liées aux utilisateurs concernés

- le freelances peut voir toutes les annonces (pour postuler) 
- le freelances ne peut voir que ses projets
- l'entreprise ne peut voir que ses annonces et que ses projets